### PR TITLE
Projects: separator line inside card is too thick

### DIFF
--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -42,7 +42,7 @@ const TopContainer = styled.div`
 
 const BottomContainer = styled.div`
   padding: ${space(4, 6)};
-  border-top: 3px solid ${color("gray", 200)};
+  border-top: 1px solid ${color("gray", 200)};
   display: flex;
   justify-content: flex-end;
 `;


### PR DESCRIPTION
This PR fixes the separator line bug that appeared too thick (not matching design).  The separator line in the project cards is now the specified design width. 