### PR TITLE
Issue List: Page info has the wrong color

### DIFF
--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -53,7 +53,7 @@ const PaginationButton = styled.button`
 `;
 
 const PageInfo = styled.div`
-  color: ${color("gray", 300)};
+  color: ${color("gray", 700)};
   ${textFont("sm", "regular")}
 `;
 


### PR DESCRIPTION
This PR adjusts the page info color to a darker gray to match the design spec.