### PR TITLE
Sidebar Navigation: Support button should open the user’s mail app

### DIFF
--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -27,11 +27,11 @@ describe("Sidebar Navigation", () => {
 
       // Get window object to access it methods for stubs
       cy.window().then((win) => {
-        // alias window.open function with 'open' so it be referenced later with '@open'
+        // alias window.open function so it can be referenced later with '@open'
         cy.stub(win, "open").as("open");
       });
 
-      // This opens the new window (mail client)
+      // This opens the new window (mail client) and should trigger the stubben window.open method
       cy.get("nav").contains("Support").click();
       cy.get("@open").should(
         "be.always.calledWith",

--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -24,6 +24,19 @@ describe("Sidebar Navigation", () => {
 
       cy.get("nav").contains("Settings").click();
       cy.url().should("eq", "http://localhost:3000/dashboard/settings");
+
+      // Get window object to access it methods for stubs
+      cy.window().then((win) => {
+        // alias window.open function with 'open' so it be referenced later with '@open'
+        cy.stub(win, "open").as("open");
+      });
+
+      // This opens the new window (mail client)
+      cy.get("nav").contains("Support").click();
+      cy.get("@open").should(
+        "be.always.calledWith",
+        "mailto:support@prolog-app.com?subject=Support Request:"
+      );
     });
 
     it("is collapsible", () => {

--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -31,7 +31,7 @@ describe("Sidebar Navigation", () => {
         cy.stub(win, "open").as("open");
       });
 
-      // This opens the new window (mail client) and should trigger the stubben window.open method
+      // This opens the new window (mail client) and should trigger the stubbed window.open method
       cy.get("nav").contains("Support").click();
       cy.get("@open").should(
         "be.always.calledWith",

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -195,7 +195,11 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                window.open(
+                  "mailto:support@prolog-app.com?subject=Support Request:"
+                )
+              }
             />
             <CollapseMenuItem
               text="Collapse"


### PR DESCRIPTION
This PR adds the functionality of opening the user's mail app when clicking the "Support" button, and pre-fills certain fields with required info. Cypress test coverage is included.