### PR TITLE
Sidebar Navigation: Wrong logo when switching to mobile view

### DIFF
--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -27,11 +27,11 @@ describe("Sidebar Navigation", () => {
 
       // Get window object to access it methods for stubs
       cy.window().then((win) => {
-        // alias window.open function with 'open' so it be referenced later with '@open'
+        // alias window.open function so it can be referenced later with '@open'
         cy.stub(win, "open").as("open");
       });
 
-      // This opens the new window (mail client)
+      // This opens the new window (mail client) and should trigger the stubben window.open method
       cy.get("nav").contains("Support").click();
       cy.get("@open").should(
         "be.always.calledWith",

--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -24,6 +24,19 @@ describe("Sidebar Navigation", () => {
 
       cy.get("nav").contains("Settings").click();
       cy.url().should("eq", "http://localhost:3000/dashboard/settings");
+
+      // Get window object to access it methods for stubs
+      cy.window().then((win) => {
+        // alias window.open function with 'open' so it be referenced later with '@open'
+        cy.stub(win, "open").as("open");
+      });
+
+      // This opens the new window (mail client)
+      cy.get("nav").contains("Support").click();
+      cy.get("@open").should(
+        "be.always.calledWith",
+        "mailto:support@prolog-app.com?subject=Support Request:"
+      );
     });
 
     it("is collapsible", () => {

--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -31,7 +31,7 @@ describe("Sidebar Navigation", () => {
         cy.stub(win, "open").as("open");
       });
 
-      // This opens the new window (mail client) and should trigger the stubben window.open method
+      // This opens the new window (mail client) and should trigger the stubbed window.open method
       cy.get("nav").contains("Support").click();
       cy.get("@open").should(
         "be.always.calledWith",

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -6,7 +6,7 @@ import { NavigationContext } from "./navigation-context";
 import { MenuItemButton } from "./menu-item-button";
 import { MenuItemLink } from "./menu-item-link";
 import { Button } from "@features/ui";
-import { breakpoint, color, space, zIndex } from "@styles/theme";
+import { breakpoint, color, theme, space, zIndex } from "@styles/theme";
 
 const menuItems = [
   { text: "Projects", iconSrc: "/icons/projects.svg", href: Routes.projects },
@@ -68,11 +68,29 @@ const Header = styled.header`
   }
 `;
 
-const Logo = styled.img`
+const Logo = styled.picture`
   width: 7.375rem;
+
+  /* Ensure the mobile logo is preferentially displayed on smaller screens */
+  /* &.desktopLogo {
+    display: none;
+  }
+
+  &.mobileLogo {
+    display: block;
+  } */
 
   @media (min-width: ${breakpoint("desktop")}) {
     margin: ${space(0, 4)};
+
+    /* Ensure the dynamic desktop logo is preferentially displayed on larger screens */
+    /* &.desktopLogo {
+      display: block;
+    }
+
+    &.mobileLogo {
+      display: none;
+    } */
   }
 `;
 
@@ -162,14 +180,37 @@ export function SidebarNavigation() {
     <Container isCollapsed={isSidebarCollapsed}>
       <FixedContainer>
         <Header>
+          {/* <Logo
+            className="mobileLogo"
+            src="/icons/logo-large.svg"
+            alt="logo"
+          />
           <Logo
+            className="desktopLogo"
             src={
               isSidebarCollapsed
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }
             alt="logo"
-          />
+          /> */}
+
+          <Logo>
+            <source
+              media={`(max-width: ${theme.breakpoint.desktop})`}
+              srcSet="/icons/logo-large.svg"
+            />
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={
+                isSidebarCollapsed
+                  ? "/icons/logo-small.svg"
+                  : "/icons/logo-large.svg"
+              }
+              alt="logo"
+            />
+          </Logo>
+
           <MenuButton onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}>
             <MenuIcon
               src={isMobileMenuOpen ? "/icons/close.svg" : "/icons/menu.svg"}

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -195,7 +195,11 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() =>
+                window.open(
+                  "mailto:support@prolog-app.com?subject=Support Request:"
+                )
+              }
             />
             <CollapseMenuItem
               text="Collapse"


### PR DESCRIPTION
This PR proposes a change to the Logo element from an `img` tag to the newer html `picture` element. This will allow us to dynamically change the image source using a CSS-style media query, and avoids pre-loading both image sizes on initial page load. 

The `picture` element is not fully supported across all browsers, and so an alternate but less ideal solution has been left in comment form pending clarification on browser support requirements. If this PR is approved, these comments will be removed. 