### PR TITLE
Sidebar Navigation: Wrong logo when switching to mobile view

### DIFF
--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -6,7 +6,7 @@ import { NavigationContext } from "./navigation-context";
 import { MenuItemButton } from "./menu-item-button";
 import { MenuItemLink } from "./menu-item-link";
 import { Button } from "@features/ui";
-import { breakpoint, color, space, zIndex } from "@styles/theme";
+import { breakpoint, color, theme, space, zIndex } from "@styles/theme";
 
 const menuItems = [
   { text: "Projects", iconSrc: "/icons/projects.svg", href: Routes.projects },
@@ -68,11 +68,29 @@ const Header = styled.header`
   }
 `;
 
-const Logo = styled.img`
+const Logo = styled.picture`
   width: 7.375rem;
+
+  /* Ensure the mobile logo is preferentially displayed on smaller screens */
+  /* &.desktopLogo {
+    display: none;
+  }
+
+  &.mobileLogo {
+    display: block;
+  } */
 
   @media (min-width: ${breakpoint("desktop")}) {
     margin: ${space(0, 4)};
+
+    /* Ensure the dynamic desktop logo is preferentially displayed on larger screens */
+    /* &.desktopLogo {
+      display: block;
+    }
+
+    &.mobileLogo {
+      display: none;
+    } */
   }
 `;
 
@@ -162,14 +180,36 @@ export function SidebarNavigation() {
     <Container isCollapsed={isSidebarCollapsed}>
       <FixedContainer>
         <Header>
+          {/* <Logo
+            className="mobileLogo"
+            src="/icons/logo-large.svg"
+            alt="logo"
+          />
           <Logo
+            className="desktopLogo"
             src={
               isSidebarCollapsed
                 ? "/icons/logo-small.svg"
                 : "/icons/logo-large.svg"
             }
             alt="logo"
-          />
+          /> */}
+
+          <Logo>
+            <source
+              media={`(max-width: ${theme.breakpoint.desktop})`}
+              srcSet="/icons/logo-large.svg"
+            />
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={
+                isSidebarCollapsed
+                  ? "/icons/logo-small.svg"
+                  : "/icons/logo-large.svg"
+              }
+              alt="logo"
+            />
+          </Logo>
           <MenuButton onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}>
             <MenuIcon
               src={isMobileMenuOpen ? "/icons/close.svg" : "/icons/menu.svg"}

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -71,26 +71,8 @@ const Header = styled.header`
 const Logo = styled.picture`
   width: 7.375rem;
 
-  /* Ensure the mobile logo is preferentially displayed on smaller screens */
-  /* &.desktopLogo {
-    display: none;
-  }
-
-  &.mobileLogo {
-    display: block;
-  } */
-
   @media (min-width: ${breakpoint("desktop")}) {
     margin: ${space(0, 4)};
-
-    /* Ensure the dynamic desktop logo is preferentially displayed on larger screens */
-    /* &.desktopLogo {
-      display: block;
-    }
-
-    &.mobileLogo {
-      display: none;
-    } */
   }
 `;
 
@@ -180,21 +162,6 @@ export function SidebarNavigation() {
     <Container isCollapsed={isSidebarCollapsed}>
       <FixedContainer>
         <Header>
-          {/* <Logo
-            className="mobileLogo"
-            src="/icons/logo-large.svg"
-            alt="logo"
-          />
-          <Logo
-            className="desktopLogo"
-            src={
-              isSidebarCollapsed
-                ? "/icons/logo-small.svg"
-                : "/icons/logo-large.svg"
-            }
-            alt="logo"
-          /> */}
-
           <Logo>
             <source
               media={`(max-width: ${theme.breakpoint.desktop})`}


### PR DESCRIPTION
This PR proposes a change to the Logo element from an img tag to the newer html picture element. This will allow us to dynamically change the image source using a CSS-style media query, and avoids pre-loading both image sizes on initial page load.

The picture element is not fully supported across all browsers, and so an alternate but less ideal solution has been left in comment form pending clarification on browser support requirements. If this PR is approved, these comments will be removed.