### PR TITLE
Projects: Project list doesn’t show correct status

### DIFF
--- a/cypress/integration/project-list.spec.ts
+++ b/cypress/integration/project-list.spec.ts
@@ -22,6 +22,7 @@ describe("Project List", () => {
 
     it("renders the projects", () => {
       const languageNames = ["React", "Node.js", "Python"];
+      const statusNames = ["Critical", "Warning", "Stable"];
 
       // get all project cards
       cy.get("main")
@@ -32,7 +33,7 @@ describe("Project List", () => {
           cy.wrap($el).contains(languageNames[index]);
           cy.wrap($el).contains(mockProjects[index].numIssues);
           cy.wrap($el).contains(mockProjects[index].numEvents24h);
-          cy.wrap($el).contains(capitalize(mockProjects[index].status));
+          cy.wrap($el).contains(statusNames[index]);
           cy.wrap($el)
             .find("a")
             .should("have.attr", "href", "/dashboard/issues");

--- a/cypress/integration/project-list.spec.ts
+++ b/cypress/integration/project-list.spec.ts
@@ -1,4 +1,3 @@
-import capitalize from "lodash/capitalize";
 import mockProjects from "../fixtures/projects.json";
 
 describe("Project List", () => {

--- a/features/projects/components/project-card/project-card.stories.tsx
+++ b/features/projects/components/project-card/project-card.stories.tsx
@@ -26,7 +26,7 @@ Default.args = {
     language: ProjectLanguage.react,
     numIssues: 420,
     numEvents24h: 721,
-    status: ProjectStatus.critical,
+    status: ProjectStatus.error,
   },
 };
 Default.parameters = {

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
 import styled from "styled-components";
-import capitalize from "lodash/capitalize";
 import { Badge, BadgeColor } from "@features/ui";
 import {
   Project,
@@ -21,9 +20,9 @@ const languageNames = {
 };
 
 const statusColors = {
-  [ProjectStatus.stable]: BadgeColor.success,
+  [ProjectStatus.info]: BadgeColor.success,
   [ProjectStatus.warning]: BadgeColor.warning,
-  [ProjectStatus.critical]: BadgeColor.error,
+  [ProjectStatus.error]: BadgeColor.error,
 };
 
 const Container = styled.div`

--- a/features/projects/components/project-card/project-card.tsx
+++ b/features/projects/components/project-card/project-card.tsx
@@ -106,6 +106,21 @@ const ViewIssuesAnchor = styled.a`
 
 export function ProjectCard({ project }: ProjectCardProps) {
   const { name, language, numIssues, numEvents24h, status } = project;
+
+  // Used to switch out the default status text returned from API to a preferred text for the UI
+  const modifyStatusTextForUI = (statusText: string) => {
+    switch (statusText) {
+      case "warning":
+        return "Warning";
+      case "info":
+        return "Stable";
+      case "error":
+        return "Critical";
+      default:
+        break;
+    }
+  };
+
   return (
     <Container>
       <TopContainer>
@@ -126,7 +141,9 @@ export function ProjectCard({ project }: ProjectCardProps) {
             <IssuesNumber>{numEvents24h}</IssuesNumber>
           </Issues>
           <Status>
-            <Badge color={statusColors[status]}>{capitalize(status)}</Badge>
+            <Badge color={statusColors[status]}>
+              {modifyStatusTextForUI(status)}
+            </Badge>
           </Status>
         </InfoContainer>
       </TopContainer>

--- a/features/projects/types/project.types.ts
+++ b/features/projects/types/project.types.ts
@@ -5,9 +5,9 @@ export enum ProjectLanguage {
 }
 
 export enum ProjectStatus {
-  stable = "stable",
+  info = "info",
+  error = "error",
   warning = "warning",
-  critical = "critical",
 }
 
 export type Project = {

--- a/features/ui/badge/badge.tsx
+++ b/features/ui/badge/badge.tsx
@@ -58,6 +58,7 @@ const Container = styled.div<{ size: BadgeSize; color: BadgeColor }>`
           background: ${color("gray", 100)};
           color: ${color("gray", 700)};
         `;
+
       default:
         return css`
           background: ${color(props.color, 50)};

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -177,14 +177,7 @@ export function SidebarNavigation() {
               alt="logo"
             />
           </Logo>
-          <MenuButton onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}>
-            <MenuIcon
-              src={isMobileMenuOpen ? "/icons/close.svg" : "/icons/menu.svg"}
-              alt={isMobileMenuOpen ? "close menu" : "open menu"}
-            />
-          </MenuButton>
         </Header>
-        <MenuOverlay isMobileMenuOpen={isMobileMenuOpen} />
         <Nav isMobileMenuOpen={isMobileMenuOpen}>
           <LinkList>
             {menuItems.map((menuItem, index) => (

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -177,6 +177,12 @@ export function SidebarNavigation() {
               alt="logo"
             />
           </Logo>
+          <MenuButton onClick={() => setMobileMenuOpen(!isMobileMenuOpen)}>
+            <MenuIcon
+              src={isMobileMenuOpen ? "/icons/close.svg" : "/icons/menu.svg"}
+              alt={isMobileMenuOpen ? "close menu" : "open menu"}
+            />
+          </MenuButton>
         </Header>
         <Nav isMobileMenuOpen={isMobileMenuOpen}>
           <LinkList>


### PR DESCRIPTION
This PR addresses the following acceptance criteria regarding the titled issue:
- The color of the status badge matches the project status
- The text writes “Critical” for the error status and “Stable” for the info status
- Covered with a Cypress test