### PR TITLE
Issue List: number of events and users is the same

### DIFF
--- a/cypress/integration/issue-list.spec.ts
+++ b/cypress/integration/issue-list.spec.ts
@@ -45,6 +45,7 @@ describe("Issue List", () => {
           cy.wrap($el).contains(issue.name);
           cy.wrap($el).contains(issue.message);
           cy.wrap($el).contains(issue.numEvents);
+          cy.wrap($el).contains(issue.numUsers);
           cy.wrap($el).contains(firstLineOfStackTrace);
         });
     });

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -48,7 +48,7 @@ const ErrorType = styled.span`
 `;
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
-  const { name, message, stack, level, numEvents } = issue;
+  const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
   return (
     <Row>
@@ -71,7 +71,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
         </Badge>
       </Cell>
       <Cell>{numEvents}</Cell>
-      <Cell>{numEvents}</Cell>
+      <Cell>{numUsers}</Cell>
     </Row>
   );
 }

--- a/features/issues/types/issue.types.ts
+++ b/features/issues/types/issue.types.ts
@@ -12,4 +12,5 @@ export type Issue = {
   stack: string;
   level: IssueLevel;
   numEvents: number;
+  numUsers: number;
 };


### PR DESCRIPTION
This PR fixes the titled issue and meets the following acceptance criteria
- The numbers in the “Events” and “Users” columns match the API data
- Covered by a Cypress test