### PR TITLE
Menu link refactor

### DIFF
--- a/cypress/integration/navigation.spec.ts
+++ b/cypress/integration/navigation.spec.ts
@@ -25,18 +25,14 @@ describe("Sidebar Navigation", () => {
       cy.get("nav").contains("Settings").click();
       cy.url().should("eq", "http://localhost:3000/dashboard/settings");
 
-      // Get window object to access it methods for stubs
-      cy.window().then((win) => {
-        // alias window.open function so it can be referenced later with '@open'
-        cy.stub(win, "open").as("open");
-      });
-
-      // This opens the new window (mail client) and should trigger the stubbed window.open method
-      cy.get("nav").contains("Support").click();
-      cy.get("@open").should(
-        "be.always.calledWith",
-        "mailto:support@prolog-app.com?subject=Support Request:"
-      );
+      // Do not click this link because it opens an external application
+      cy.get("nav")
+        .contains("Support")
+        .should(
+          "have.attr",
+          "href",
+          "mailto:support@prolog-app.com?subject=Support Request:"
+        );
     });
 
     it("is collapsible", () => {
@@ -46,7 +42,7 @@ describe("Sidebar Navigation", () => {
       // check that links still exist and are functionable
       cy.get("[data-cy='sidebarNav']")
         .find("a")
-        .should("have.length", 5)
+        .should("have.length", 6)
         .eq(1)
         .click();
       cy.url().should("eq", "http://localhost:3000/dashboard/issues");
@@ -92,7 +88,7 @@ describe("Sidebar Navigation", () => {
       isInViewport("nav");
 
       // check that all links are rendered
-      cy.get("[data-cy='sidebarNav']").find("a").should("have.length", 5);
+      cy.get("[data-cy='sidebarNav']").find("a").should("have.length", 6);
 
       // Support button should be rendered but Collapse button not
       cy.get("nav").contains("Support").should("exist");

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -200,15 +200,12 @@ export function SidebarNavigation() {
           </LinkList>
 
           <List>
-            <MenuItemButton
+            <MenuItemLink
               text="Support"
+              href="mailto:support@prolog-app.com?subject=Support Request:"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() =>
-                window.open(
-                  "mailto:support@prolog-app.com?subject=Support Request:"
-                )
-              }
+              isActive={false}
             />
             <CollapseMenuItem
               text="Collapse"


### PR DESCRIPTION
This PR switches the Support button from a `MenuItemButton` to a `MenuItemLink` component for ease of use and simpler testing. Discussed originally with PR #4.