### PR TITLE
Create Mobile Design for Issues Page

### DIFF
--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -89,15 +89,15 @@ const HeaderCell = styled.th`
   ${textFont("xs", "medium")};
 `;
 
-const PaginationContainer = styled.div`
+const DesktopPagination = styled.div`
   display: none;
-  align-items: center;
-  justify-content: space-between;
-  padding: ${space(4, 6)};
-  border-top: 1px solid ${color("gray", 200)};
 
   @media (min-width: ${breakpoint("issueTableBreak")}) {
     display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-top: 1px solid ${color("gray", 200)};
+    padding: ${space(4, 6)};
   }
 `;
 
@@ -114,21 +114,21 @@ const PaginationButton = styled.button`
   }
 `;
 
-const MobilePaginationContainer = styled.div`
+const PageInfo = styled.div`
+  color: ${color("gray", 700)};
+  ${textFont("sm", "regular")};
+`;
+
+const PageNumber = styled.span`
+  ${textFont("sm", "medium")};
+`;
+
+const MobilePagination = styled.div`
   margin-bottom: ${space(4)};
 
   @media (min-width: ${breakpoint("issueTableBreak")}) {
     display: none;
   }
-`;
-
-const PageInfo = styled.div`
-  color: ${color("gray", 700)};
-  ${textFont("sm", "regular")}
-`;
-
-const PageNumber = styled.span`
-  ${textFont("sm", "medium")}
 `;
 
 export function IssueList() {
@@ -215,35 +215,36 @@ export function IssueList() {
             ))}
           </tbody>
         </Table>
-        <PaginationContainer>
-          <div>
-            <PaginationButton
-              onClick={() => navigateToPage(page - 1)}
-              disabled={page === 1}
+        <div>
+          <DesktopPagination>
+            <div>
+              <PaginationButton
+                onClick={() => navigateToPage(page - 1)}
+                disabled={page === 1}
+              >
+                Previous
+              </PaginationButton>
+              <PaginationButton
+                onClick={() => navigateToPage(page + 1)}
+                disabled={page === meta?.totalPages}
+              >
+                Next
+              </PaginationButton>
+            </div>
+            <PageInfo>
+              Page <PageNumber>{meta?.currentPage}</PageNumber> of{" "}
+              <PageNumber>{meta?.totalPages}</PageNumber>
+            </PageInfo>
+          </DesktopPagination>
+          <MobilePagination>
+            <Button
+              onClick={() => alert("To be implemented")}
+              color={ButtonColor.gray}
             >
-              Previous
-            </PaginationButton>
-            <PaginationButton
-              onClick={() => navigateToPage(page + 1)}
-              disabled={page === meta?.totalPages}
-            >
-              Next
-            </PaginationButton>
-          </div>
-          <PageInfo>
-            Page <PageNumber>{meta?.currentPage}</PageNumber> of{" "}
-            <PageNumber>{meta?.totalPages}</PageNumber>
-          </PageInfo>
-        </PaginationContainer>
-
-        <MobilePaginationContainer>
-          <Button
-            onClick={() => alert("To be implemented")}
-            color={ButtonColor.gray}
-          >
-            Load more
-          </Button>
-        </MobilePaginationContainer>
+              Load more
+            </Button>
+          </MobilePagination>
+        </div>
       </ListContainer>
     </div>
   );

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -10,8 +10,12 @@ import { ButtonSize, IconDisplay } from "@features/ui/button/button";
 const OptionsContainer = styled.div`
   display: flex;
   justify-content: space-between;
-  max-height: 44px;
   padding-bottom: 1.56rem;
+  gap: ${space(4)};
+`;
+
+const ButtonContainer = styled.div`
+  flex-shrink: 0;
 `;
 
 const ListContainer = styled.div`
@@ -120,12 +124,17 @@ export function IssueList() {
   return (
     <div>
       <OptionsContainer>
-        <Button
-          size={ButtonSize.lg}
-          icon={{ src: "/icons/tick-white.svg", display: IconDisplay.leading }}
-        >
-          Resolve selected issues
-        </Button>
+        <ButtonContainer>
+          <Button
+            size={ButtonSize.lg}
+            icon={{
+              src: "/icons/tick-white.svg",
+              display: IconDisplay.leading,
+            }}
+          >
+            Resolve selected issues
+          </Button>
+        </ButtonContainer>
         <IssueFilters />
       </OptionsContainer>
       <ListContainer>

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -4,6 +4,15 @@ import { IssueFilters, useIssues } from "@features/issues";
 import { ProjectLanguage, useProjects } from "@features/projects";
 import { color, space, textFont } from "@styles/theme";
 import { IssueRow } from "./Issue-row";
+import { Button } from "@features/ui";
+import { ButtonSize, IconDisplay } from "@features/ui/button/button";
+
+const OptionsContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  max-height: 44px;
+  padding-bottom: 1.56rem;
+`;
 
 const ListContainer = styled.div`
   background: white;
@@ -110,7 +119,15 @@ export function IssueList() {
 
   return (
     <div>
-      <IssueFilters />
+      <OptionsContainer>
+        <Button
+          size={ButtonSize.lg}
+          icon={{ src: "/icons/tick-white.svg", display: IconDisplay.leading }}
+        >
+          Resolve selected issues
+        </Button>
+        <IssueFilters />
+      </OptionsContainer>
       <ListContainer>
         <Table>
           <thead>

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -9,29 +9,45 @@ import { ButtonSize, IconDisplay } from "@features/ui/button/button";
 
 const OptionsContainer = styled.div`
   display: flex;
-  flex-direction: column;
+  flex-direction: column-reverse;
   padding-bottom: 1.56rem;
   gap: ${space(4)};
+  max-width: 40rem;
 
-  @media (min-width: ${breakpoint("desktop")}) {
+  /* @media (min-width: ${breakpoint("desktop")}) {
     flex-direction: column;
     justify-content: space-between;
+  } */
+
+  /* Issues table breaks below 650px */
+  @media (min-width: 650px) {
+    /* flex-direction: row;
+    justify-content: space-between; */
+    max-width: 30rem;
   }
 `;
 
 const ButtonContainer = styled.div`
   flex-shrink: 0;
   width: 100%;
+  @media (min-width: 500px) {
+    flex-shrink: 1;
+  }
 `;
 
 const ListContainer = styled.div`
   background: white;
-  border: 1px solid ${color("gray", 200)};
+  border: none;
   box-sizing: border-box;
-  box-shadow: 0px 4px 8px -2px rgba(16, 24, 40, 0.1),
-    0px 2px 4px -2px rgba(16, 24, 40, 0.06);
+  box-shadow: none;
   border-radius: ${space(2)};
   overflow: hidden;
+
+  @media (min-width: ${breakpoint("desktop")}) {
+    border: 1px solid ${color("gray", 200)};
+    box-shadow: 0px 4px 8px -2px rgba(16, 24, 40, 0.1),
+      0px 2px 4px -2px rgba(16, 24, 40, 0.06);
+  }
 `;
 
 const Table = styled.table`
@@ -41,6 +57,18 @@ const Table = styled.table`
 
 const HeaderRow = styled.tr`
   border-bottom: 1px solid ${color("gray", 200)};
+`;
+
+const TableHead = styled.thead`
+  left: -9999px;
+  position: absolute;
+  visibility: hidden;
+
+  @media (min-width: ${breakpoint("desktop")}) {
+    position: static;
+    left: auto;
+    visibility: visible;
+  }
 `;
 
 const HeaderCell = styled.th`
@@ -145,14 +173,14 @@ export function IssueList() {
       </OptionsContainer>
       <ListContainer>
         <Table>
-          <thead>
+          <TableHead>
             <HeaderRow>
               <HeaderCell>Issue</HeaderCell>
               <HeaderCell>Level</HeaderCell>
               <HeaderCell>Events</HeaderCell>
               <HeaderCell>Users</HeaderCell>
             </HeaderRow>
-          </thead>
+          </TableHead>
           <tbody>
             {(items || []).map((issue) => (
               <IssueRow

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -43,7 +43,7 @@ const ListContainer = styled.div`
   border-radius: ${space(2)};
   overflow: hidden;
 
-  @media (min-width: ${breakpoint("desktop")}) {
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
     border: 1px solid ${color("gray", 200)};
     box-shadow: 0px 4px 8px -2px rgba(16, 24, 40, 0.1),
       0px 2px 4px -2px rgba(16, 24, 40, 0.06);
@@ -55,7 +55,7 @@ const Table = styled.table`
   border-collapse: collapse;
   table-layout: fixed;
 
-  @media (min-width: ${breakpoint("desktop")}) {
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
     table-layout: auto;
   }
 `;
@@ -69,7 +69,7 @@ const TableHead = styled.thead`
   position: absolute;
   visibility: hidden;
 
-  @media (min-width: ${breakpoint("desktop")}) {
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
     position: static;
     left: auto;
     visibility: visible;

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -53,6 +53,11 @@ const ListContainer = styled.div`
 const Table = styled.table`
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
+
+  @media (min-width: ${breakpoint("desktop")}) {
+    table-layout: auto;
+  }
 `;
 
 const HeaderRow = styled.tr`

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -184,6 +184,7 @@ export function IssueList() {
         <ButtonContainer>
           <Button
             size={ButtonSize.lg}
+            onClick={() => alert("To be implemented")}
             icon={{
               src: "/icons/tick-white.svg",
               display: IconDisplay.leading,

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -5,7 +5,11 @@ import { ProjectLanguage, useProjects } from "@features/projects";
 import { breakpoint, color, space, textFont } from "@styles/theme";
 import { IssueRow } from "./Issue-row";
 import { Button } from "@features/ui";
-import { ButtonSize, IconDisplay } from "@features/ui/button/button";
+import {
+  ButtonColor,
+  ButtonSize,
+  IconDisplay,
+} from "@features/ui/button/button";
 
 const OptionsContainer = styled.div`
   display: flex;
@@ -84,11 +88,15 @@ const HeaderCell = styled.th`
 `;
 
 const PaginationContainer = styled.div`
-  display: flex;
+  display: none;
   align-items: center;
   justify-content: space-between;
   padding: ${space(4, 6)};
   border-top: 1px solid ${color("gray", 200)};
+
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
+    display: flex;
+  }
 `;
 
 const PaginationButton = styled.button`
@@ -101,6 +109,15 @@ const PaginationButton = styled.button`
 
   &:not(:first-of-type) {
     margin-left: ${space(3)};
+  }
+`;
+
+const MobilePaginationContainer = styled.div`
+  margin-bottom: ${space(4)};
+  overflow: visible;
+
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
+    display: none;
   }
 `;
 
@@ -216,6 +233,15 @@ export function IssueList() {
             <PageNumber>{meta?.totalPages}</PageNumber>
           </PageInfo>
         </PaginationContainer>
+
+        <MobilePaginationContainer>
+          <Button
+            onClick={() => alert("To be implemented")}
+            color={ButtonColor.gray}
+          >
+            Load more
+          </Button>
+        </MobilePaginationContainer>
       </ListContainer>
     </div>
   );

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -16,7 +16,6 @@ const OptionsContainer = styled.div`
   flex-direction: column-reverse;
   padding-bottom: 1.56rem;
   gap: ${space(4)};
-  max-width: 40rem;
 
   @media (min-width: ${breakpoint("issueTableBreak")}) {
     flex-direction: row;
@@ -37,10 +36,8 @@ const ButtonContainer = styled.div`
   }
 
   @media (min-width: ${breakpoint("issueOptionsBreak")}) {
-    flex-shrink: 1;
     width: auto;
     max-width: auto;
-    display: block;
   }
 `;
 
@@ -119,7 +116,6 @@ const PaginationButton = styled.button`
 
 const MobilePaginationContainer = styled.div`
   margin-bottom: ${space(4)};
-  overflow: visible;
 
   @media (min-width: ${breakpoint("issueTableBreak")}) {
     display: none;

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -18,24 +18,29 @@ const OptionsContainer = styled.div`
   gap: ${space(4)};
   max-width: 40rem;
 
-  /* @media (min-width: ${breakpoint("desktop")}) {
-    flex-direction: column;
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
+    flex-direction: row;
     justify-content: space-between;
-  } */
-
-  /* Issues table breaks below 650px */
-  @media (min-width: 650px) {
-    /* flex-direction: row;
-    justify-content: space-between; */
-    max-width: 30rem;
+    max-width: 100%;
   }
 `;
 
 const ButtonContainer = styled.div`
   flex-shrink: 0;
   width: 100%;
-  @media (min-width: 500px) {
+  display: flex;
+  align-items: center;
+
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
     flex-shrink: 1;
+    max-width: 50%;
+  }
+
+  @media (min-width: ${breakpoint("issueOptionsBreak")}) {
+    flex-shrink: 1;
+    width: auto;
+    max-width: auto;
+    display: block;
   }
 `;
 

--- a/features/issues/components/IssueList/Issue-list.tsx
+++ b/features/issues/components/IssueList/Issue-list.tsx
@@ -2,20 +2,26 @@ import { useRouter } from "next/router";
 import styled from "styled-components";
 import { IssueFilters, useIssues } from "@features/issues";
 import { ProjectLanguage, useProjects } from "@features/projects";
-import { color, space, textFont } from "@styles/theme";
+import { breakpoint, color, space, textFont } from "@styles/theme";
 import { IssueRow } from "./Issue-row";
 import { Button } from "@features/ui";
 import { ButtonSize, IconDisplay } from "@features/ui/button/button";
 
 const OptionsContainer = styled.div`
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
   padding-bottom: 1.56rem;
   gap: ${space(4)};
+
+  @media (min-width: ${breakpoint("desktop")}) {
+    flex-direction: column;
+    justify-content: space-between;
+  }
 `;
 
 const ButtonContainer = styled.div`
   flex-shrink: 0;
+  width: 100%;
 `;
 
 const ListContainer = styled.div`

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -18,15 +18,7 @@ const levelColors = {
 };
 
 const Row = styled.tr`
-  border: 1px solid ${color("gray", 200)};
-  display: flex;
-  flex-direction: column;
-  margin-bottom: 2rem;
-  border-collapse: separate;
-  border-radius: ${space(2)};
-  border-spacing: 0;
-  box-shadow: 0px 1px 3px rgba(16, 24, 40, 0.1),
-    0px 1px 2px rgba(16, 24, 40, 0.06);
+  display: none;
 
   @media (min-width: ${breakpoint("desktop")}) {
     border: none;
@@ -40,6 +32,22 @@ const Row = styled.tr`
   }
 `;
 
+const MobileRow = styled.div`
+  border: 1px solid ${color("gray", 200)};
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 2rem;
+  border-collapse: separate;
+  border-radius: ${space(2)};
+  border-spacing: 0;
+  box-shadow: 0px 1px 3px rgba(16, 24, 40, 0.1),
+    0px 1px 2px rgba(16, 24, 40, 0.06);
+
+  @media (min-width: ${breakpoint("desktop")}) {
+    display: none;
+  }
+`;
+
 const Cell = styled.td`
   padding: ${space(4, 6)};
   color: ${color("gray", 500)};
@@ -49,6 +57,25 @@ const Cell = styled.td`
 const IssueCell = styled(Cell)`
   display: flex;
   align-items: center;
+`;
+
+const StatsContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: ${space(4, 0)};
+`;
+
+const MobileCell = styled(Cell)`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: space-between;
+`;
+
+const CellTitle = styled.span`
+  color: ${color("gray", 500)};
+  ${textFont("sm", "medium")}
 `;
 
 const LanguageIcon = styled.img`
@@ -68,27 +95,61 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
   const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
   return (
-    <Row>
-      <IssueCell>
-        <LanguageIcon
-          src={`/icons/${projectLanguage}.svg`}
-          alt={projectLanguage}
-        />
-        <div>
-          <ErrorTypeAndMessage>
-            <ErrorType>{name}:&nbsp;</ErrorType>
-            {message}
-          </ErrorTypeAndMessage>
-          <div>{firstLineOfStackTrace}</div>
-        </div>
-      </IssueCell>
-      <Cell>
-        <Badge color={levelColors[level]} size={BadgeSize.sm}>
-          {capitalize(level)}
-        </Badge>
-      </Cell>
-      <Cell>{numEvents}</Cell>
-      <Cell>{numUsers}</Cell>
-    </Row>
+    <>
+      <Row>
+        <IssueCell>
+          <LanguageIcon
+            src={`/icons/${projectLanguage}.svg`}
+            alt={projectLanguage}
+          />
+          <div>
+            <ErrorTypeAndMessage>
+              <ErrorType>{name}:&nbsp;</ErrorType>
+              {message}
+            </ErrorTypeAndMessage>
+            <div>{firstLineOfStackTrace}</div>
+          </div>
+        </IssueCell>
+        <Cell>
+          <Badge color={levelColors[level]} size={BadgeSize.sm}>
+            {capitalize(level)}
+          </Badge>
+        </Cell>
+        <Cell>{numEvents}</Cell>
+        <Cell>{numUsers}</Cell>
+      </Row>
+
+      <MobileRow>
+        <IssueCell>
+          <LanguageIcon
+            src={`/icons/${projectLanguage}.svg`}
+            alt={projectLanguage}
+          />
+          <div>
+            <ErrorTypeAndMessage>
+              <ErrorType>{name}:&nbsp;</ErrorType>
+              {message}
+            </ErrorTypeAndMessage>
+            <div>{firstLineOfStackTrace}</div>
+          </div>
+        </IssueCell>
+        <StatsContainer>
+          <MobileCell>
+            <CellTitle>Status</CellTitle>
+            <Badge color={levelColors[level]} size={BadgeSize.sm}>
+              {capitalize(level)}
+            </Badge>
+          </MobileCell>
+          <MobileCell>
+            <CellTitle>Events</CellTitle>
+            {numEvents}
+          </MobileCell>
+          <MobileCell>
+            <CellTitle>Users</CellTitle>
+            {numUsers}
+          </MobileCell>
+        </StatsContainer>
+      </MobileRow>
+    </>
   );
 }

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -27,6 +27,10 @@ const Cell = styled.td`
   padding: ${space(4, 6)};
   color: ${color("gray", 500)};
   ${textFont("sm", "regular")}
+  &:nth-of-type(3) {
+    border-radius: 6px;
+    width: 100%;
+  }
 `;
 
 const IssueCell = styled(Cell)`

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -32,7 +32,7 @@ const Row = styled.tr`
   }
 `;
 
-const MobileRow = styled.div`
+const MobileRow = styled.tr`
   border: 1px solid ${color("gray", 200)};
   padding: ${space(3, 6)};
   display: flex;
@@ -70,7 +70,7 @@ const IssueCell = styled(Cell)`
   }
 `;
 
-const StatsContainer = styled.div`
+const StatsCell = styled.td`
   display: flex;
   align-items: center;
   justify-content: space-evenly;
@@ -78,7 +78,7 @@ const StatsContainer = styled.div`
   padding: ${space(4, 0)};
 `;
 
-const MobileCell = styled(Cell)`
+const InnerCellContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -86,6 +86,8 @@ const MobileCell = styled(Cell)`
   gap: ${space(2)};
   padding: 0;
   width: 100%;
+  color: ${color("gray", 500)};
+  ${textFont("sm", "regular")};
 `;
 
 const CellTitle = styled.span`
@@ -154,22 +156,22 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
             <div>{firstLineOfStackTrace}</div>
           </ErrorContainer>
         </IssueCell>
-        <StatsContainer>
-          <MobileCell>
+        <StatsCell>
+          <InnerCellContainer>
             <CellTitle>Status</CellTitle>
             <Badge color={levelColors[level]} size={BadgeSize.sm}>
               {capitalize(level)}
             </Badge>
-          </MobileCell>
-          <MobileCell>
+          </InnerCellContainer>
+          <InnerCellContainer>
             <CellTitle>Events</CellTitle>
             {numEvents}
-          </MobileCell>
-          <MobileCell>
+          </InnerCellContainer>
+          <InnerCellContainer>
             <CellTitle>Users</CellTitle>
             {numUsers}
-          </MobileCell>
-        </StatsContainer>
+          </InnerCellContainer>
+        </StatsCell>
       </MobileRow>
     </>
   );

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -34,8 +34,10 @@ const Row = styled.tr`
 
 const MobileRow = styled.div`
   border: 1px solid ${color("gray", 200)};
+  padding: ${space(3, 6)};
   display: flex;
   flex-direction: column;
+  gap: ${space(2)};
   margin-bottom: 2rem;
   border-collapse: separate;
   border-radius: ${space(2)};
@@ -49,9 +51,13 @@ const MobileRow = styled.div`
 `;
 
 const Cell = styled.td`
-  padding: ${space(4, 6)};
+  padding: 0;
   color: ${color("gray", 500)};
-  ${textFont("sm", "regular")}
+  ${textFont("sm", "regular")};
+
+  @media (min-width: ${breakpoint("desktop")}) {
+    padding: ${space(4, 6)};
+  }
 `;
 
 const IssueCell = styled(Cell)`
@@ -62,7 +68,8 @@ const IssueCell = styled(Cell)`
 const StatsContainer = styled.div`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-evenly;
+  gap: 0.625rem;
   padding: ${space(4, 0)};
 `;
 
@@ -71,6 +78,9 @@ const MobileCell = styled(Cell)`
   flex-direction: column;
   align-items: center;
   justify-content: space-between;
+  gap: ${space(2)};
+  padding: 0;
+  width: 100%;
 `;
 
 const CellTitle = styled.span`

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -23,13 +23,10 @@ const Row = styled.tr`
   grid-template-rows: auto;
   row-gap: 0.5625rem;
   column-gap: 0.625rem;
-
   border: 1px solid ${color("gray", 200)};
   padding: ${space(3, 6)};
   margin-bottom: ${space(4)};
-  border-collapse: separate;
   border-radius: ${space(2)};
-  border-spacing: 0;
   box-shadow: 0px 1px 3px rgba(16, 24, 40, 0.1),
     0px 1px 2px rgba(16, 24, 40, 0.06);
 

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -1,6 +1,6 @@
 import styled from "styled-components";
 import capitalize from "lodash/capitalize";
-import { color, space, textFont } from "@styles/theme";
+import { breakpoint, color, space, textFont } from "@styles/theme";
 import { Badge, BadgeColor, BadgeSize } from "@features/ui";
 import { IssueLevel } from "../../types/issue.types";
 import { ProjectLanguage } from "@features/projects";
@@ -18,8 +18,25 @@ const levelColors = {
 };
 
 const Row = styled.tr`
-  &:nth-child(2n) {
-    background: ${color("gray", 50)};
+  border: 1px solid ${color("gray", 200)};
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 2rem;
+  border-collapse: separate;
+  border-radius: ${space(2)};
+  border-spacing: 0;
+  box-shadow: 0px 1px 3px rgba(16, 24, 40, 0.1),
+    0px 1px 2px rgba(16, 24, 40, 0.06);
+
+  @media (min-width: ${breakpoint("desktop")}) {
+    border: none;
+    display: table-row;
+    margin-bottom: 0;
+    box-shadow: none;
+
+    &:nth-child(2n) {
+      background: ${color("gray", 50)};
+    }
   }
 `;
 
@@ -27,10 +44,6 @@ const Cell = styled.td`
   padding: ${space(4, 6)};
   color: ${color("gray", 500)};
   ${textFont("sm", "regular")}
-  &:nth-of-type(3) {
-    border-radius: 6px;
-    width: 100%;
-  }
 `;
 
 const IssueCell = styled(Cell)`

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -63,6 +63,7 @@ const Cell = styled.td`
 const IssueCell = styled(Cell)`
   display: flex;
   align-items: center;
+  padding: ${space(4, 0)};
 `;
 
 const StatsContainer = styled.div`
@@ -93,12 +94,18 @@ const LanguageIcon = styled.img`
   margin-right: ${space(3)};
 `;
 
+const ErrorContainer = styled.div`
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;
+
 const ErrorTypeAndMessage = styled.div`
   color: ${color("gray", 900)};
 `;
 
 const ErrorType = styled.span`
-  ${textFont("sm", "medium")}
+  ${textFont("sm", "medium")};
 `;
 
 export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
@@ -115,7 +122,7 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
           <div>
             <ErrorTypeAndMessage>
               <ErrorType>{name}:&nbsp;</ErrorType>
-              {message}
+              <span>{message}</span>
             </ErrorTypeAndMessage>
             <div>{firstLineOfStackTrace}</div>
           </div>
@@ -135,13 +142,13 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
             src={`/icons/${projectLanguage}.svg`}
             alt={projectLanguage}
           />
-          <div>
+          <ErrorContainer>
             <ErrorTypeAndMessage>
               <ErrorType>{name}:&nbsp;</ErrorType>
               {message}
             </ErrorTypeAndMessage>
             <div>{firstLineOfStackTrace}</div>
-          </div>
+          </ErrorContainer>
         </IssueCell>
         <StatsContainer>
           <MobileCell>

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -20,7 +20,7 @@ const levelColors = {
 const Row = styled.tr`
   display: none;
 
-  @media (min-width: ${breakpoint("desktop")}) {
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
     border: none;
     display: table-row;
     margin-bottom: 0;
@@ -38,14 +38,14 @@ const MobileRow = styled.div`
   display: flex;
   flex-direction: column;
   gap: ${space(2)};
-  margin-bottom: 2rem;
+  margin-bottom: ${space(4)};
   border-collapse: separate;
   border-radius: ${space(2)};
   border-spacing: 0;
   box-shadow: 0px 1px 3px rgba(16, 24, 40, 0.1),
     0px 1px 2px rgba(16, 24, 40, 0.06);
 
-  @media (min-width: ${breakpoint("desktop")}) {
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
     display: none;
   }
 `;
@@ -55,7 +55,7 @@ const Cell = styled.td`
   color: ${color("gray", 500)};
   ${textFont("sm", "regular")};
 
-  @media (min-width: ${breakpoint("desktop")}) {
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
     padding: ${space(4, 6)};
   }
 `;
@@ -64,6 +64,10 @@ const IssueCell = styled(Cell)`
   display: flex;
   align-items: center;
   padding: ${space(4, 0)};
+
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
+    padding: ${space(4, 6)};
+  }
 `;
 
 const StatsContainer = styled.div`

--- a/features/issues/components/IssueList/Issue-row.tsx
+++ b/features/issues/components/IssueList/Issue-row.tsx
@@ -18,7 +18,20 @@ const levelColors = {
 };
 
 const Row = styled.tr`
-  display: none;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-template-rows: auto;
+  row-gap: 0.5625rem;
+  column-gap: 0.625rem;
+
+  border: 1px solid ${color("gray", 200)};
+  padding: ${space(3, 6)};
+  margin-bottom: ${space(4)};
+  border-collapse: separate;
+  border-radius: ${space(2)};
+  border-spacing: 0;
+  box-shadow: 0px 1px 3px rgba(16, 24, 40, 0.1),
+    0px 1px 2px rgba(16, 24, 40, 0.06);
 
   @media (min-width: ${breakpoint("issueTableBreak")}) {
     border: none;
@@ -32,67 +45,41 @@ const Row = styled.tr`
   }
 `;
 
-const MobileRow = styled.tr`
-  border: 1px solid ${color("gray", 200)};
-  padding: ${space(3, 6)};
-  display: flex;
-  flex-direction: column;
-  gap: ${space(2)};
-  margin-bottom: ${space(4)};
-  border-collapse: separate;
-  border-radius: ${space(2)};
-  border-spacing: 0;
-  box-shadow: 0px 1px 3px rgba(16, 24, 40, 0.1),
-    0px 1px 2px rgba(16, 24, 40, 0.06);
-
-  @media (min-width: ${breakpoint("issueTableBreak")}) {
-    display: none;
-  }
-`;
-
 const Cell = styled.td`
-  padding: 0;
+  padding: ${space(4, 0)};
   color: ${color("gray", 500)};
   ${textFont("sm", "regular")};
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: ${space(2)};
+  width: 100%;
 
   @media (min-width: ${breakpoint("issueTableBreak")}) {
+    display: table-cell;
+    width: auto;
+    gap: 0;
     padding: ${space(4, 6)};
   }
 `;
 
 const IssueCell = styled(Cell)`
   display: flex;
-  align-items: center;
+  flex-direction: row;
   padding: ${space(4, 0)};
+  grid-column: 1 / span 3;
 
   @media (min-width: ${breakpoint("issueTableBreak")}) {
     padding: ${space(4, 6)};
   }
 `;
 
-const StatsCell = styled.td`
-  display: flex;
-  align-items: center;
-  justify-content: space-evenly;
-  gap: 0.625rem;
-  padding: ${space(4, 0)};
-`;
-
-const InnerCellContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: space-between;
-  gap: ${space(2)};
-  padding: 0;
-  width: 100%;
-  color: ${color("gray", 500)};
-  ${textFont("sm", "regular")};
-`;
-
 const CellTitle = styled.span`
-  color: ${color("gray", 500)};
-  ${textFont("sm", "medium")}
+  ${textFont("sm", "medium")};
+
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
+    display: none;
+  }
 `;
 
 const LanguageIcon = styled.img`
@@ -102,8 +89,11 @@ const LanguageIcon = styled.img`
 
 const ErrorContainer = styled.div`
   overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
+
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
+    white-space: normal;
+  }
 `;
 
 const ErrorTypeAndMessage = styled.div`
@@ -118,61 +108,34 @@ export function IssueRow({ projectLanguage, issue }: IssueRowProps) {
   const { name, message, stack, level, numEvents, numUsers } = issue;
   const firstLineOfStackTrace = stack.split("\n")[1];
   return (
-    <>
-      <Row>
-        <IssueCell>
-          <LanguageIcon
-            src={`/icons/${projectLanguage}.svg`}
-            alt={projectLanguage}
-          />
-          <div>
-            <ErrorTypeAndMessage>
-              <ErrorType>{name}:&nbsp;</ErrorType>
-              <span>{message}</span>
-            </ErrorTypeAndMessage>
-            <div>{firstLineOfStackTrace}</div>
-          </div>
-        </IssueCell>
-        <Cell>
-          <Badge color={levelColors[level]} size={BadgeSize.sm}>
-            {capitalize(level)}
-          </Badge>
-        </Cell>
-        <Cell>{numEvents}</Cell>
-        <Cell>{numUsers}</Cell>
-      </Row>
-
-      <MobileRow>
-        <IssueCell>
-          <LanguageIcon
-            src={`/icons/${projectLanguage}.svg`}
-            alt={projectLanguage}
-          />
-          <ErrorContainer>
-            <ErrorTypeAndMessage>
-              <ErrorType>{name}:&nbsp;</ErrorType>
-              {message}
-            </ErrorTypeAndMessage>
-            <div>{firstLineOfStackTrace}</div>
-          </ErrorContainer>
-        </IssueCell>
-        <StatsCell>
-          <InnerCellContainer>
-            <CellTitle>Status</CellTitle>
-            <Badge color={levelColors[level]} size={BadgeSize.sm}>
-              {capitalize(level)}
-            </Badge>
-          </InnerCellContainer>
-          <InnerCellContainer>
-            <CellTitle>Events</CellTitle>
-            {numEvents}
-          </InnerCellContainer>
-          <InnerCellContainer>
-            <CellTitle>Users</CellTitle>
-            {numUsers}
-          </InnerCellContainer>
-        </StatsCell>
-      </MobileRow>
-    </>
+    <Row>
+      <IssueCell>
+        <LanguageIcon
+          src={`/icons/${projectLanguage}.svg`}
+          alt={projectLanguage}
+        />
+        <ErrorContainer>
+          <ErrorTypeAndMessage>
+            <ErrorType>{name}:&nbsp;</ErrorType>
+            <span>{message}</span>
+          </ErrorTypeAndMessage>
+          <div>{firstLineOfStackTrace}</div>
+        </ErrorContainer>
+      </IssueCell>
+      <Cell>
+        <CellTitle>Status</CellTitle>
+        <Badge color={levelColors[level]} size={BadgeSize.sm}>
+          {capitalize(level)}
+        </Badge>
+      </Cell>
+      <Cell>
+        <CellTitle>Events</CellTitle>
+        {numEvents}
+      </Cell>
+      <Cell>
+        <CellTitle>Users</CellTitle>
+        {numUsers}
+      </Cell>
+    </Row>
   );
 }

--- a/features/issues/components/issue-filters/issue-filters.tsx
+++ b/features/issues/components/issue-filters/issue-filters.tsx
@@ -44,9 +44,13 @@ const Container = styled.div`
   flex-direction: column;
   gap: ${space(4)};
 
-  @media (min-width: ${breakpoint("desktop")}) {
+  @media (min-width: ${breakpoint("issueTableBreak")}) {
+    width: 50%;
+  }
+
+  @media (min-width: ${breakpoint("issueOptionsBreak")}) {
     display: grid;
-    grid-template-columns: 10rem 10rem minmax(10rem, 17.5rem);
+    grid-template-columns: 10rem minmax(8.5rem, 10rem) minmax(10rem, 17.5rem);
     align-items: center;
     justify-content: end;
   }

--- a/features/issues/components/issue-filters/issue-filters.tsx
+++ b/features/issues/components/issue-filters/issue-filters.tsx
@@ -51,7 +51,6 @@ const Container = styled.div`
   @media (min-width: ${breakpoint("issueOptionsBreak")}) {
     display: grid;
     grid-template-columns: 10rem minmax(8.5rem, 10rem) minmax(10rem, 17.5rem);
-    align-items: center;
     justify-content: end;
   }
 `;

--- a/features/issues/components/issue-filters/issue-filters.tsx
+++ b/features/issues/components/issue-filters/issue-filters.tsx
@@ -1,11 +1,5 @@
 import { IssueLevel, IssueStatus } from "@features/issues/types/issue.types";
-import { Button, Checkbox, Input, SelectComponent } from "@features/ui";
-import {
-  ButtonColor,
-  ButtonSize,
-  IconDisplay,
-} from "@features/ui/button/button";
-import { CheckboxSize, CheckboxState } from "@features/ui/checkbox/checkbox";
+import { Input, SelectComponent } from "@features/ui";
 import { space } from "@styles/theme";
 import { NextRouter, useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -51,7 +45,6 @@ const Container = styled.div`
   align-items: center;
   justify-content: end;
   gap: ${space(4)};
-  padding-bottom: 1.125rem;
 `;
 
 // Defined outside the component to make useCallback/useEffect dependency decisions easier to understand
@@ -95,11 +88,6 @@ export function IssueFilters() {
 
   return (
     <Container>
-      <Checkbox
-        label="Test"
-        checkboxState={CheckboxState.unchecked}
-        checkboxSize={CheckboxSize.md}
-      />
       <SelectComponent
         placeholder="Status"
         options={statusOptions}
@@ -142,7 +130,7 @@ export function IssueFilters() {
       />
       <Input
         placeholder="Project Name"
-        // iconSrc="/icons/search.svg"
+        iconSrc="/icons/search.svg"
         onChange={(event) => setRealTimeValue(event.currentTarget.value)}
         data-cy="projectInput"
         value={realTimeValue}

--- a/features/issues/components/issue-filters/issue-filters.tsx
+++ b/features/issues/components/issue-filters/issue-filters.tsx
@@ -1,5 +1,11 @@
 import { IssueLevel, IssueStatus } from "@features/issues/types/issue.types";
-import { Input, SelectComponent } from "@features/ui";
+import { Button, Checkbox, Input, SelectComponent } from "@features/ui";
+import {
+  ButtonColor,
+  ButtonSize,
+  IconDisplay,
+} from "@features/ui/button/button";
+import { CheckboxSize, CheckboxState } from "@features/ui/checkbox/checkbox";
 import { space } from "@styles/theme";
 import { NextRouter, useRouter } from "next/router";
 import { useEffect, useState } from "react";
@@ -89,6 +95,11 @@ export function IssueFilters() {
 
   return (
     <Container>
+      <Checkbox
+        label="Test"
+        checkboxState={CheckboxState.unchecked}
+        checkboxSize={CheckboxSize.md}
+      />
       <SelectComponent
         placeholder="Status"
         options={statusOptions}
@@ -131,7 +142,7 @@ export function IssueFilters() {
       />
       <Input
         placeholder="Project Name"
-        iconSrc="/icons/search.svg"
+        // iconSrc="/icons/search.svg"
         onChange={(event) => setRealTimeValue(event.currentTarget.value)}
         data-cy="projectInput"
         value={realTimeValue}

--- a/features/issues/components/issue-filters/issue-filters.tsx
+++ b/features/issues/components/issue-filters/issue-filters.tsx
@@ -1,6 +1,6 @@
 import { IssueLevel, IssueStatus } from "@features/issues/types/issue.types";
 import { Input, SelectComponent } from "@features/ui";
-import { space } from "@styles/theme";
+import { breakpoint, space } from "@styles/theme";
 import { NextRouter, useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
@@ -40,11 +40,16 @@ const levelOptions: OptionType[] = [
 ];
 
 const Container = styled.div`
-  display: grid;
-  grid-template-columns: 10rem 10rem minmax(10rem, 17.5rem);
-  align-items: center;
-  justify-content: end;
+  display: flex;
+  flex-direction: column;
   gap: ${space(4)};
+
+  @media (min-width: ${breakpoint("desktop")}) {
+    display: grid;
+    grid-template-columns: 10rem 10rem minmax(10rem, 17.5rem);
+    align-items: center;
+    justify-content: end;
+  }
 `;
 
 // Defined outside the component to make useCallback/useEffect dependency decisions easier to understand

--- a/features/issues/components/issue-filters/issue-filters.tsx
+++ b/features/issues/components/issue-filters/issue-filters.tsx
@@ -41,7 +41,7 @@ const levelOptions: OptionType[] = [
 
 const Container = styled.div`
   display: grid;
-  grid-template-columns: 10rem 10rem 17.5rem;
+  grid-template-columns: 10rem 10rem minmax(10rem, 17.5rem);
   align-items: center;
   justify-content: end;
   gap: ${space(4)};

--- a/features/ui/button/button.tsx
+++ b/features/ui/button/button.tsx
@@ -65,7 +65,7 @@ export const Container = styled.button<{
   iconDisplay: IconDisplay;
 }>`
   ${ButtonCSSReset}
-
+  width: 100%;
   box-sizing: border-box;
   display: flex;
   justify-content: center;

--- a/features/ui/button/button.tsx
+++ b/features/ui/button/button.tsx
@@ -35,8 +35,8 @@ export interface IconOptions {
 
 export type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   icon?: IconOptions;
-  size: ButtonSize;
-  color: ButtonColor;
+  size?: ButtonSize;
+  color?: ButtonColor;
 };
 
 // Used in place of the previous "Button" export whose only purpose was essentially providing a CSS reset to button styles

--- a/features/ui/button/button.tsx
+++ b/features/ui/button/button.tsx
@@ -80,24 +80,24 @@ export const Container = styled.button<{
     switch (props.size) {
       case ButtonSize.sm:
         return css`
-          padding: 0.5rem 0.875rem;
+          padding: 0.4375rem 0.875rem;
         `;
 
       case ButtonSize.md:
         return css`
-          padding: 0.625rem 1rem;
+          padding: 0.5625rem 1rem;
         `;
 
       case ButtonSize.lg:
         return css`
           ${textFont("md", "medium")}
-          padding: 0.625rem 1.125rem;
+          padding: 0.5625rem 1.125rem;
         `;
 
       case ButtonSize.xl:
         return css`
           ${textFont("md", "medium")}
-          padding: 0.75rem 1.25rem;
+          padding: 0.6875rem 1.25rem;
         `;
     }
   }}

--- a/features/ui/input/input.tsx
+++ b/features/ui/input/input.tsx
@@ -14,7 +14,6 @@ export type InputProps = InputHTMLAttributes<HTMLInputElement> & {
 const Container = styled.label`
   display: flex;
   flex-direction: column;
-  max-width: 20rem;
 `;
 
 const LabelText = styled.span`

--- a/features/ui/page-container/page-container.tsx
+++ b/features/ui/page-container/page-container.tsx
@@ -3,7 +3,6 @@ import Head from "next/head";
 import styled from "styled-components";
 import { SidebarNavigation, Footer } from "@features/ui";
 import { color, displayFont, textFont, space, breakpoint } from "@styles/theme";
-import { SelectComponent } from "../select";
 
 type PageContainerProps = {
   children: React.ReactNode;
@@ -15,6 +14,7 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   background: ${color("gray", 900)};
+  z-index: 100;
 
   @media (min-width: ${breakpoint("desktop")}) {
     flex-direction: row;

--- a/features/ui/page-container/page-container.tsx
+++ b/features/ui/page-container/page-container.tsx
@@ -14,7 +14,6 @@ const Container = styled.div`
   display: flex;
   flex-direction: column;
   background: ${color("gray", 900)};
-  z-index: 100;
 
   @media (min-width: ${breakpoint("desktop")}) {
     flex-direction: row;

--- a/features/ui/select/select.tsx
+++ b/features/ui/select/select.tsx
@@ -149,7 +149,6 @@ const Placeholder = ({ children, ...props }: PlaceholderProps) => (
 const customStyles: StylesConfig = {
   control: (provided, state) => ({
     ...provided,
-    maxWidth: "20rem",
     borderWidth: "1px",
     borderColor: state.selectProps.hasError
       ? `${color("error", 300)({ theme })}`
@@ -185,7 +184,6 @@ const customStyles: StylesConfig = {
 
   menu: (provided) => ({
     ...provided,
-    maxWidth: "20rem",
     boxShadow:
       "0px 12px 16px -4px rgba(16, 24, 40, 0.1), 0px 4px 6px -2px rgba(16, 24, 40, 0.05)",
     borderRadius: "8px",

--- a/features/ui/select/select.tsx
+++ b/features/ui/select/select.tsx
@@ -163,7 +163,12 @@ const customStyles: StylesConfig = {
         : "0px 1px 2px rgba(16, 24, 40, 0.05), 0px 0px 0px 4px #F4EBFF;"
       : "0px 1px 2px rgba(16, 24, 40, 0.05)",
     padding: "0.5625rem 0.8125rem",
-    margin: "6px 0",
+    margin:
+      state.selectProps.label ||
+      state.selectProps.errorMsg ||
+      state.selectProps.hintMsg
+        ? "6px 0"
+        : "0",
     backgroundColor: state.isDisabled
       ? `${color("gray", 50)({ theme })}`
       : "#FFFFFF",

--- a/features/ui/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/ui/sidebar-navigation/sidebar-navigation.tsx
@@ -20,6 +20,7 @@ const containerStyles = css`
   width: 100%;
   display: flex;
   flex-direction: column;
+  z-index: 2;
 
   @media (min-width: ${breakpoint("desktop")}) {
     width: 17.5rem;

--- a/public/icons/tick-white.svg
+++ b/public/icons/tick-white.svg
@@ -1,0 +1,3 @@
+<svg width="16" height="12" viewBox="0 0 16 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M14.6667 1L5.50001 10.1667L1.33334 6" stroke="white" stroke-width="1.67" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -48,6 +48,7 @@ export type Theme = {
   };
   breakpoint: {
     desktop: string;
+    issueOptionsBreak: string;
     issueTableBreak: string;
   };
   zIndex: {
@@ -156,6 +157,7 @@ export const theme = {
   },
   breakpoint: {
     desktop: "64em",
+    issueOptionsBreak: "1120px",
     issueTableBreak: "650px",
   },
   zIndex: {

--- a/styles/theme.ts
+++ b/styles/theme.ts
@@ -48,6 +48,7 @@ export type Theme = {
   };
   breakpoint: {
     desktop: string;
+    issueTableBreak: string;
   };
   zIndex: {
     header: number;
@@ -155,6 +156,7 @@ export const theme = {
   },
   breakpoint: {
     desktop: "64em",
+    issueTableBreak: "650px",
   },
   zIndex: {
     header: 1000,


### PR DESCRIPTION
This PR adds a mobile page design for the Issues page. It meets the following acceptance criteria:
- The issues page matches the designs on mobile
- While decreasing the window width from desktop to mobile the layout should be usable

A 'tablet' range design has been added to bridge mobile and desktop designs regarding the issue filters and buttons above the issues table. The desktop design breaks earlier than the issues table but switching to a mobile filter design at this large breakpoint (>1000px) is inappropriate, hence an intermediary design is added. Some guidance on how this design might be improved would be helpful.